### PR TITLE
Fix warnings and update test calls

### DIFF
--- a/src/document.mbt
+++ b/src/document.mbt
@@ -41,13 +41,10 @@ pub fn char(c : Char) -> Document {
 
 ///| Concatenate documents.
 pub fn list(ls : Array[Document]) -> Document {
-  fn aux {
-    ([] : ArrayView[_]) => Empty
-    [x, y] => concat(x, y)
-    [x, .. xs] => concat(x, aux(xs))
+  match ls {
+    [] => Empty
+    [x, .. xs] => xs.iter().fold(init=x, concat)
   }
-
-  aux(ls[:])
 }
 
 ///| `group(doc)` tries to render the `doc` on a single line, 

--- a/src/document_test.mbt
+++ b/src/document_test.mbt
@@ -6,7 +6,7 @@ test "pretty group" {
       @prettyprinter.hardline + @prettyprinter.text("world"),
     ),
   )
-  inspect!(
+  inspect(
     doc.to_string(),
     content=
       #|hello

--- a/src/example/tree.mbt
+++ b/src/example/tree.mbt
@@ -35,7 +35,7 @@ test {
     ]),
     Leaf(1000),
   ])
-  inspect!(
+  inspect(
     @pp.render(tree, width=50),
     content=
       #|Node(

--- a/src/pretty.mbt
+++ b/src/pretty.mbt
@@ -158,7 +158,10 @@ pub impl[A : Pretty, B : Pretty] Pretty for Result[A, B] with pretty(res) {
 pub impl[A : Pretty, B : Pretty] Pretty for Map[A, B] with pretty(m) {
   let entries = m
     .iter()
-    .map(fn { (k, v) => group(k.pretty() + char(':') + space + v.pretty()) })
+    .map(fn(pair) {
+      let (k, v) = pair
+      group(k.pretty() + char(':') + space + v.pretty())
+    })
     .to_array()
   group(
     char('{') +
@@ -346,7 +349,10 @@ pub impl[A : Pretty] Pretty for FixedArray[A] with pretty(array) {
 pub impl[A : Pretty, B : Pretty] Pretty for @hashmap.T[A, B] with pretty(map) {
   let entries = map
     .iter()
-    .map(fn { (k, v) => group(k.pretty() + char(':') + space + v.pretty()) })
+    .map(fn(pair) {
+      let (k, v) = pair
+      group(k.pretty() + char(':') + space + v.pretty())
+    })
     .to_array()
   group(
     braces(
@@ -385,7 +391,10 @@ pub impl[A : Pretty] Pretty for @hashset.T[A] with pretty(set) {
 pub impl[A : Pretty, B : Pretty] Pretty for @sorted_map.T[A, B] with pretty(map) {
   let entries = map
     .iter()
-    .map(fn { (k, v) => group(k.pretty() + char(':') + space + v.pretty()) })
+    .map(fn(pair) {
+      let (k, v) = pair
+      group(k.pretty() + char(':') + space + v.pretty())
+    })
     .to_array()
   group(
     braces(
@@ -452,7 +461,10 @@ pub impl[A : Pretty, B : Pretty] Pretty for @immut/hashmap.T[A, B] with pretty(
 ) {
   let entries = map
     .iter()
-    .map(fn { (k, v) => group(k.pretty() + char(':') + space + v.pretty()) })
+    .map(fn(pair) {
+      let (k, v) = pair
+      group(k.pretty() + char(':') + space + v.pretty())
+    })
     .to_array()
   group(
     braces(
@@ -477,7 +489,10 @@ pub impl[A : Pretty, B : Pretty] Pretty for @immut/sorted_map.T[A, B] with prett
 ) {
   let entries = map
     .iter()
-    .map(fn { (k, v) => group(k.pretty() + char(':') + space + v.pretty()) })
+    .map(fn(pair) {
+      let (k, v) = pair
+      group(k.pretty() + char(':') + space + v.pretty())
+    })
     .to_array()
   group(
     braces(

--- a/src/pretty_tuple_wtest.mbt
+++ b/src/pretty_tuple_wtest.mbt
@@ -1,8 +1,8 @@
 ///|
 test {
   let tuple = (1, 'a')
-  inspect!(pretty(tuple), content="(1, a)")
-  inspect!(
+  inspect(pretty(tuple), content="(1, a)")
+  inspect(
     render(tuple, width=3),
     content=
       #|(
@@ -12,8 +12,8 @@ test {
     ,
   )
   let tuple = (1, 'a', false)
-  inspect!(pretty(tuple), content="(1, a, false)")
-  inspect!(
+  inspect(pretty(tuple), content="(1, a, false)")
+  inspect(
     render(tuple, width=3),
     content=
       #|(
@@ -24,8 +24,8 @@ test {
     ,
   )
   let tuple = (1, 'a', false, 1.5)
-  inspect!(pretty(tuple), content="(1, a, false, 1.5)")
-  inspect!(
+  inspect(pretty(tuple), content="(1, a, false, 1.5)")
+  inspect(
     render(tuple, width=3),
     content=
       #|(
@@ -37,8 +37,8 @@ test {
     ,
   )
   let tuple = (1, 'a', false, 1.5, Some(1))
-  inspect!(pretty(tuple), content="(1, a, false, 1.5, Some(1))")
-  inspect!(
+  inspect(pretty(tuple), content="(1, a, false, 1.5, Some(1))")
+  inspect(
     render(tuple, width=10),
     content=
       #|(
@@ -51,13 +51,13 @@ test {
     ,
   )
   let tuple = (1, 'a', false, 1.5, Some(1), "hello")
-  inspect!(
+  inspect(
     pretty(tuple),
     content=
       #|(1, a, false, 1.5, Some(1), "hello")
     ,
   )
-  inspect!(
+  inspect(
     render(tuple, width=10),
     content=
       #|(
@@ -71,13 +71,13 @@ test {
     ,
   )
   let tuple = (1, 'a', false, 1.5, Some(1), "hello", 5)
-  inspect!(
+  inspect(
     pretty(tuple),
     content=
       #|(1, a, false, 1.5, Some(1), "hello", 5)
     ,
   )
-  inspect!(
+  inspect(
     render(tuple, width=10),
     content=
       #|(
@@ -92,13 +92,13 @@ test {
     ,
   )
   let tuple = (1, 'a', false, 1.5, Some(1), "hello", 5, 6)
-  inspect!(
+  inspect(
     pretty(tuple),
     content=
       #|(1, a, false, 1.5, Some(1), "hello", 5, 6)
     ,
   )
-  inspect!(
+  inspect(
     render(tuple, width=10),
     content=
       #|(
@@ -114,13 +114,13 @@ test {
     ,
   )
   let tuple = (1, 'a', false, 1.5, Some(1), "hello", 5, 6, 7)
-  inspect!(
+  inspect(
     pretty(tuple),
     content=
       #|(1, a, false, 1.5, Some(1), "hello", 5, 6, 7)
     ,
   )
-  inspect!(
+  inspect(
     render(tuple, width=10),
     content=
       #|(

--- a/src/prettyprinter.mbti
+++ b/src/prettyprinter.mbti
@@ -55,8 +55,6 @@ fn switch(Document, Document) -> Document
 
 fn text(String) -> Document
 
-fn to_string(Document) -> String
-
 // Types and methods
 type Document
 fn Document::to_string(Self) -> String

--- a/src/utils_test.mbt
+++ b/src/utils_test.mbt
@@ -4,7 +4,7 @@ test "pretty array" {
     "aaaaaaaaaaaaaaaa", "bbbbbbbbbbbbbbbbbbbbbb", "1111111111111111222222", "3333333333333333",
     "4444",
   ]
-  inspect!(
+  inspect(
     @prettyprinter.render(ls),
     content=
       #|[
@@ -28,7 +28,7 @@ test "pretty map" {
     "50": None,
   }
   let map = { "aaa": Some(map), "bbb": None, "cc": Some({ "0": None }) }
-  inspect!(
+  inspect(
     @prettyprinter.render(map),
     content=
       #|{
@@ -62,7 +62,7 @@ test "json" {
     },
     "key3": [true, false, Null],
   }
-  inspect!(
+  inspect(
     @prettyprinter.render(json),
     content=
       #|{


### PR DESCRIPTION
## Summary
- remove deprecated matrix function in `list`
- rewrite `map` lambdas without deprecated syntax
- update tests to drop `!` from `inspect` calls
- update types via `moon info`

## Testing
- `moon fmt`
- `moon info`
- `moon check`

------
https://chatgpt.com/codex/tasks/task_e_6856ab2558ec83208e3e00abd58178b1