### PR TITLE
Fix deprecated Iterator usage and update gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 target/
 .mooncakes/
+_build/
+target

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .mooncakes/
 _build/
 target
+_build

--- a/combinator_test.mbt
+++ b/combinator_test.mbt
@@ -60,7 +60,7 @@ test "json" {
       "obj3": { "a": true, "b": true },
       "obj4": { "a": true, "b": true },
     },
-    "key3": [true, false, Null],
+    "key3": [true, false, Json::null()],
   }
   inspect(
     @prettyprinter.render(json),

--- a/pkg.generated.mbti
+++ b/pkg.generated.mbti
@@ -122,8 +122,8 @@ pub impl Pretty for Bytes
 pub impl Pretty for @bigint.BigInt
 pub impl Pretty for @buffer.Buffer
 pub impl[A : Pretty] Pretty for Array[A]
-pub impl[A : Pretty] Pretty for Iter[A]
-pub impl[A : Pretty, B : Pretty] Pretty for Iter2[A, B]
+pub impl[A : Pretty] Pretty for Iterator[A]
+pub impl[A : Pretty, B : Pretty] Pretty for Iterator2[A, B]
 pub impl Pretty for Json
 pub impl[A : Pretty, B : Pretty] Pretty for Map[A, B]
 pub impl[A : Pretty] Pretty for @deque.Deque[A]

--- a/pretty.mbt
+++ b/pretty.mbt
@@ -483,13 +483,13 @@ pub impl[A : Pretty] Pretty for @immut/array.T[A] with pretty(array) {
 }
 
 ///|
-pub impl[A : Pretty] Pretty for Iter[A] with pretty(self) {
+pub impl[A : Pretty] Pretty for Iterator[A] with pretty(self) {
   self.to_array() |> pretty()
 }
 
 ///|
-pub impl[A : Pretty, B : Pretty] Pretty for Iter2[A, B] with pretty(self) {
-  self.to_array() |> pretty()
+pub impl[A : Pretty, B : Pretty] Pretty for Iterator2[A, B] with pretty(self) {
+  self.iterator().to_array() |> pretty()
 }
 
 ///|


### PR DESCRIPTION
## Summary
- Update deprecated iterator usage in `pretty.mbt` and `combinator_test.mbt`
- Refresh generated interface changes in `pkg.generated.mbti`
- Add `target` and `_build` to `.gitignore` for upcoming migration needs

## Why
The task requires addressing deprecated warnings/errors, including the breaking change from `Iter`/`Iter2` to `Iterator`/`Iterator2`. Adding build output directories to `.gitignore` prepares the repo for future migration.

## Notable implementation details
- Adjusted iterator-related call sites to align with the new `Iterator`/`Iterator2` APIs
- Regenerated interface metadata to reflect updated public surface
- Committed `.gitignore` changes to track new ignore rules